### PR TITLE
fix/missing-overflow-scroll

### DIFF
--- a/src/pages/main-page/components/ws-display/components/ws-connect-form/ws-connection-form.tsx
+++ b/src/pages/main-page/components/ws-display/components/ws-connect-form/ws-connection-form.tsx
@@ -41,7 +41,7 @@ const WSConnectForm = ({
           <UrlControl control={control} />
         </Box>
       </Box>
-      <Box flexGrow={1}>
+      <Box flexGrow={1} overflow="auto">
         <ProtocolControl control={control} />
       </Box>
       <Box display="flex" justifyContent="flex-end" gap={1}>


### PR DESCRIPTION
**Change Log**
- Fix WebSocket protocols control not being scrollable when it overflows